### PR TITLE
feat: 实现Summary数据与Message自动集成推送 - 新增Message::toJSONDispatchWithSummar…

### DIFF
--- a/MailSync/MailStore.hpp
+++ b/MailSync/MailStore.hpp
@@ -112,6 +112,7 @@ public:
     shared_ptr<Summary> findSummaryForThread(string accountId, string threadId);
     void handleSummaryUpdate(json data, shared_ptr<Account> account);
     void handleSummaryDelete(json data, shared_ptr<Account> account);
+    void triggerMessagesWithSummaryUpdate(string accountId, string threadId);
     
     // Contact relation queries
     shared_ptr<ContactRelation> findContactRelation(string accountId, string email);

--- a/MailSync/Models/Message.hpp
+++ b/MailSync/Models/Message.hpp
@@ -146,6 +146,7 @@ public:
     void afterRemove(MailStore * store);
 
     json toJSONDispatch();
+    json toJSONDispatchWithSummary(MailStore * store = nullptr);
 
     bool _skipThreadUpdatesAfterSave;
 };


### PR DESCRIPTION
…y()方法支持合并Summary数据 - 新增MailStore::triggerMessagesWithSummaryUpdate()方法触发包含Summary的Message推送 - 修改handleSummaryUpdate()和handleSummaryDelete()自动推送相关Message数据 - Summary更新时相关线程中的所有Message会自动重新推送包含最新Summary信息 - 客户端可通过hasSummary字段判断Message是否包含Summary数据 - 简化客户端逻辑无需额外查询和数据合并操作 - 添加详细的集成方案文档SUMMARY_MESSAGE_INTEGRATION.md